### PR TITLE
Add README, redirecting to active project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# rust-rdkafka
+
+This project is not maintained anymore. [rust-rdkafka] is an alternative project, currently maintained,
+that you could use instead.
+
+[rust-rdkafka]: https://github.com/fede1024/rust-rdkafka


### PR DESCRIPTION
I'm working on a similar project and I'd like to add a link to it. This project is still one of the first results when searching for Rust client libraries for Kafka, but it doesn't seem to be maintained.